### PR TITLE
Update Spyder link to point to new website and make links HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
 		<ul>
 			<li>Designed for scientists, data-scientists, and education (thanks to <a href="http://numpy.org/">NumPy</a>, <a href="https://www.scipy.org/">SciPy</a>, <a href="https://www.sympy.org/">Sympy</a>, <a href="http://www.matplotlib.org/">Matplotlib</a>, <a href="http://pandas.pydata.org/">Pandas</a>, <a href="http://www.pyqtgraph.org/">pyqtgraph</a>, etc.):
 			<ul>
-				<li>interactive data processing and visualization using Python with <a href="https://github.com/spyder-ide">Spyder</a> and <a href="http://jupyter.org/">Jupyter/IPython</a>, or IDLE </li>
+				<li>interactive data processing and visualization using Python with <a href="https://www.spyder-ide.org/">Spyder</a> and <a href="http://jupyter.org/">Jupyter/IPython</a>, or IDLE </li>
 				<li>out-of-the-box working Compiler (Mingw64) for Python 3.4, <strong>fully integrated Cython and Numba!</strong> See <a href="http://nbviewer.ipython.org/github/winpython/winpython_afterdoc/blob/master/docs/Winpython_checker.ipynb">included example</a></li>
 				<li>connectors (cffi, odbc, rpy2, scilab2py, requests, ...) for advanced users</li>
 			</ul></li>

--- a/index.html
+++ b/index.html
@@ -24,13 +24,13 @@
 	<div id="content">
         <p>Project Home is on <a href="https://github.com/winpython">Github</a>, downloads page are on <a href="https://sourceforge.net/projects/winpython/files/">Sourceforge</a>, Discussion group is on <a href="https://groups.google.com/d/forum/winpython">Google Groups</a>,  md5 and sha1 <a href="md5_sha1.txt" />there</a> </p>
 </p>
-     
+
 		<h2 id="releases">Recent Releases </h2>
 		<p>Release <a href="https://github.com/winpython/winpython/issues/609">2018-02</a> of July 21st, 2018 </p>
 
 		<p>Highlights (**): Python-3.7.0, pandas-0.23.3, jupyterlab-0.32.1 (beta 2) + nodejs-8.11.2, scipy-1.1.0, spyder-3.3.0 (<a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonZero-64bit-3.6.6.1.md">Zero</a> Version)</p>
 		<ul>
-			<li>WinPython <strong>3.6</strong>.6.1Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.6.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.6.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.6.1/">Downloads</a></li> or <a href="https://github.com/winpython/winpython/releases/tag/1.10.20180624">Github Downloads</a></li> 
+			<li>WinPython <strong>3.6</strong>.6.1Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.6.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.6.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.6.1/">Downloads</a></li> or <a href="https://github.com/winpython/winpython/releases/tag/1.10.20180624">Github Downloads</a></li>
 			<li>WinPython <strong>3.6</strong>.6.1Qt5-32bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.6.6.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.6.6.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.6.1/">Downloads</a></li>
 			<li>WinPython <strong>3.7</strong>.0.1-64bit  (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-64bit-3.7.0.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-64bit-3.7.0.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.7/3.7.0.1/">Downloads</a></li>
 			<li>WinPython <strong>3.7</strong>.0.1-32bit  (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-32bit-3.7.0.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-32bit-3.7.0.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.7/3.7.0.1/">Downloads</a></li>
@@ -39,7 +39,7 @@
 
 		<p>Highlights (**): pandas-0.22.0, jupyterlab-0.31.12 (beta 1) + nodejs-8.9.4, matplotlib-2.2.2, spyder-3.2.8 (<a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonZero-64bit-3.6.5.0.md">Zero</a> Version)</p>
 		<ul>
-			<li>WinPython <strong>3.5</strong>.4.2Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.2_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.2.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.5/3.5.4.2/">Downloads</a> or <a href="https://github.com/winpython/winpython/releases/tag/1.10.20180404">Github Downloads</a></li> 
+			<li>WinPython <strong>3.5</strong>.4.2Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.2_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.2.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.5/3.5.4.2/">Downloads</a> or <a href="https://github.com/winpython/winpython/releases/tag/1.10.20180404">Github Downloads</a></li>
 			<li>WinPython <strong>3.5</strong>.4.2Qt5-32bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.5.4.2_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.5.4.2.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.5/3.5.4.2/">Downloads</a></li>
 			<li>WinPython <strong>3.6</strong>.5.0Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.5.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.5.0.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.5.0/">Downloads</a></li>
 			<li>WinPython <strong>3.6</strong>.5.0Qt5-32bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.6.5.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.6.5.0.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.5.0/">Downloads</a></li>
@@ -49,15 +49,15 @@
 
 		<p>Highlights: pandas-0.21.0, scipy-1.0, scikit_learn-0.19.1, statstmodels-20171031, matplotlib-2.1.0, spyder-3.2.4 (<a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonZero-64bit-3.6.3.0.md">Zero</a> Version)</p>
 		<ul>
-			<li>WinPython <strong>3.5</strong>.4.1Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.5/3.5.4.1/">Downloads</a> or <a href="https://github.com/winpython/winpython/releases/tag/1.9.20171031">Github Downloads</a></li> 
+			<li>WinPython <strong>3.5</strong>.4.1Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.5.4.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.5/3.5.4.1/">Downloads</a> or <a href="https://github.com/winpython/winpython/releases/tag/1.9.20171031">Github Downloads</a></li>
 			<li>WinPython <strong>3.5</strong>.4.1Qt5-32bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.5.4.1_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.5.4.1.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.5/3.5.4.1/">Downloads</a></li>
 			<li>WinPython <strong>3.6</strong>.3.0Qt5-64bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.3.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.3.0.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.3.0/">Downloads</a></li>
 			<li>WinPython <strong>3.6</strong>.3.0Qt5-32bit (*) <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.6.3.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-32bit-3.6.3.0.md">Packages</a> and <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.6/3.6.3.0/">Downloads</a></li>
 		</ul>
 
-        
+
 		<div class="centered"><img style="width: 125px; height: 45px;" alt="WinPython Small Logos" src="images/small_logos.png"></div>
-		
+
 		<h2 id="overview">Overview</h2>
 		<p>WinPython is a free open-source portable distribution of the <a href="https://www.python.org/">Python programming language</a> for Windows 7/8/10 and scientific and educational usage.</p>
 		<p><img style="width: 901px; height: 97px;" alt="WinPython Launcher Icons" src="images/winpython_launchers.png" /></p>
@@ -74,7 +74,7 @@
 				<li>Runs out of the box(*) on any Windows 8+ with 2GB Ram (Jupyter Notebook will require a recent browser)</li>
                 <li>The WinPython folder can be moved to any location (**) (local, network, USB drive) with most of the <a href="https://github.com/winpython/winpython/wiki/Installation#settings">application settings</a></li>
             </ul>
-			<li><strong>Flexible</strong>: 
+			<li><strong>Flexible</strong>:
 			<ul>
 				<li>You can install as many WinPython distributions as you want on the same machine: each one is isolated and self-consistent</li>
 				<li>These installations can be of different versions of Python (3.5/3.6/3.7/...) and different architectures (32bit/64bit)</li>
@@ -93,7 +93,7 @@
 			<li><strong>do your own version</strong>: a winpython-creator <a href="https://sourceforge.net/projects/winpython/files/WinPython_Source/Do_It_Yourself/">kit</a> is made available for you</li>
 		</ul>
 		<div class="centered"><img style="width: 125px; height: 45px;" alt="WinPython Small Logos" src="images/small_logos.png" /></div>
-		
+
 		<h2 id="portable">Portable or not, the choice is yours!</h2>
 		<p>WinPython is a portable application, so the user should not expect any integration into Windows explorer during <a href="https://github.com/winpython/winpython/wiki/Installation">installation</a>. However, the <a href="https://github.com/winpython/winpython/wiki/Winpython-Control-Panel">WinPython Control Panel</a> allows to "register" your distribution to Windows (see screenshot below).</p>
 		<p><img style="width: 453px; height: 152px;" alt="WinPython Register" src="images/wpcp_register_2741.png" /></p>
@@ -107,7 +107,7 @@
 		That is exactly what the official Python installer would do to your machine: in other words, you can have it both ways!
 
 		<p>(*) For recent WinPython, Windows 7/8 users may have to install <a href="https://www.visualstudio.com/fr/downloads/">Microsoft Visual C++ Redistributable for Visual Studio 2017</a>
-		<p>(**) For best Winpython 2018-01 experience, it is recommanded to have Winpython base directory path smaller than 37 characters. example: C:\Users\xxxxxxxx\Downloads\WinPython 
+		<p>(**) For best Winpython 2018-01 experience, it is recommanded to have Winpython base directory path smaller than 37 characters. example: C:\Users\xxxxxxxx\Downloads\WinPython
 	</p>
 	<div class="centered"><img style="width: 125px; height: 45px;" alt="WinPython Small Logos" src="images/small_logos.png"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC
   "-//W3C//DTD XHTML 1.1//EN"
   "https://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml/" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
     <meta content="text/html;charset=UTF-8" http-equiv="Content-Type" />
     <link href="favicon.ico" rel="icon" />

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC
   "-//W3C//DTD XHTML 1.1//EN"
-  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  "https://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml/" lang="en">
 <head>
     <meta content="text/html;charset=UTF-8" http-equiv="Content-Type" />
     <link href="favicon.ico" rel="icon" />
@@ -63,10 +63,10 @@
 		<p><img style="width: 901px; height: 97px;" alt="WinPython Launcher Icons" src="images/winpython_launchers.png" /></p>
 		<p>It is a full-featured (see our <a href="https://github.com/winpython/winpython/wiki">Wiki</a>) Python-based scientific environment:</p>
 		<ul>
-			<li>Designed for scientists, data-scientists, and education (thanks to <a href="http://numpy.org/">NumPy</a>, <a href="https://www.scipy.org/">SciPy</a>, <a href="https://www.sympy.org/">Sympy</a>, <a href="http://www.matplotlib.org/">Matplotlib</a>, <a href="http://pandas.pydata.org/">Pandas</a>, <a href="http://www.pyqtgraph.org/">pyqtgraph</a>, etc.):
+			<li>Designed for scientists, data-scientists, and education (thanks to <a href="https://www.numpy.org/">NumPy</a>, <a href="https://www.scipy.org/">SciPy</a>, <a href="https://www.sympy.org/">Sympy</a>, <a href="https://matplotlib.org/">Matplotlib</a>, <a href="https://pandas.pydata.org/">Pandas</a>, <a href="http://www.pyqtgraph.org/">pyqtgraph</a>, etc.):
 			<ul>
-				<li>interactive data processing and visualization using Python with <a href="https://www.spyder-ide.org/">Spyder</a> and <a href="http://jupyter.org/">Jupyter/IPython</a>, or IDLE </li>
-				<li>out-of-the-box working Compiler (Mingw64) for Python 3.4, <strong>fully integrated Cython and Numba!</strong> See <a href="http://nbviewer.ipython.org/github/winpython/winpython_afterdoc/blob/master/docs/Winpython_checker.ipynb">included example</a></li>
+				<li>interactive data processing and visualization using Python with <a href="https://www.spyder-ide.org/">Spyder</a> and <a href="https://jupyter.org/">Jupyter/IPython</a>, or IDLE </li>
+				<li>out-of-the-box working Compiler (Mingw64) for Python 3.4, <strong>fully integrated Cython and Numba!</strong> See <a href="https://nbviewer.ipython.org/github/winpython/winpython_afterdoc/blob/master/docs/Winpython_checker.ipynb">included example</a></li>
 				<li>connectors (cffi, odbc, rpy2, scilab2py, requests, ...) for advanced users</li>
 			</ul></li>
 			<li><strong>Portable</strong>:


### PR DESCRIPTION
@stonebig This PR does a few simple things:

* Updates the Spyder link to point to our new website
* Converts legacy HTTP links HTTPS where available to conform to modern best practices
* Cleans up a few bits of trailing whitespace in ``index.html``

If you don't want one or both of the last two for whatever reason, I have no problem dropping those commits, but figured I'd do a bit of clearnup while I was at it.

Thanks!

Part of spyder-ide/spyder-docs#39