### PR TITLE
Fix 2021-05 Python & Pyside component version numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
 
 			<p>WinPython <strong>3.10</strong> Downloads (**) via <a href="https://sourceforge.net/projects/winpython/files/WinPython_3.10/3.10.2.0/">SourceForge</a></li> and <a href="https://github.com/winpython/winpython/releases/tag/4.6.20220116">Github</a>  </p>
 			
-			<li>WinPython64-<strong>3.10</strong>.2.0dot = Python 3.9.10 64bit only : <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-64bit-3.10.2.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-64bit-3.10.2.0.md">Packages</a></li>
-			<li>WinPython32-<strong>3.10</strong>.2.0dot = Python 3.9.10 32bit only : <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-32bit-3.10.2.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-32bit-3.10.2.0.md">Packages</a></li>
-			<li>WinPython64-<strong>3.10</strong>.2.0 = Python 3.9.10 64bit + Pyside6 + Jupyterlab : <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-64bit-3.10.2.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-64bit-3.10.2.0.md">Packages</a></li>
+			<li>WinPython64-<strong>3.10</strong>.2.0dot = Python 3.10.2 64bit only : <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-64bit-3.10.2.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-64bit-3.10.2.0.md">Packages</a></li>
+			<li>WinPython32-<strong>3.10</strong>.2.0dot = Python 3.10.2 32bit only : <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-32bit-3.10.2.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPythondot-32bit-3.10.2.0.md">Packages</a></li>
+			<li>WinPython64-<strong>3.10</strong>.2.0 = Python 3.10.2 64bit + Pyside2 + Jupyterlab : <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-64bit-3.10.2.0_History.md">Changelog</a>, <a href="https://github.com/winpython/winpython/blob/master/changelogs/WinPython-64bit-3.10.2.0.md">Packages</a></li>
 
 		</ul>
 		


### PR DESCRIPTION
- The Python version after the equal sign does not match with that on the left. For the 3.10 series of releases, the Python version on the right side of the equal sign should say `Python 3.10.2 64bit` rather than `Python 3.9.10 64bit`.
- `Pyside6` is listed as a component after the equal sign, which is not correct. The release actually contains `Pyside2` as noted in the change log.

![image](https://user-images.githubusercontent.com/23555/152793590-05224dc6-dc58-4632-9e98-7ade4523835e.png)